### PR TITLE
Add option to set default resync

### DIFF
--- a/skop/informer.go
+++ b/skop/informer.go
@@ -2,6 +2,7 @@ package skop
 
 import (
 	"reflect"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -26,6 +27,7 @@ type k8sInformer struct {
 func newK8sInformer(
 	config *rest.Config,
 	namespace string,
+	defaultResync time.Duration,
 	gvr schema.GroupVersionResource,
 	resourceType reflect.Type,
 ) (*k8sInformer, error) {
@@ -34,7 +36,7 @@ func newK8sInformer(
 		return nil, err
 	}
 
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, namespace, nil)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, defaultResync, namespace, nil)
 	informer := factory.ForResource(gvr).Informer()
 
 	return &k8sInformer{

--- a/skop/operator.go
+++ b/skop/operator.go
@@ -20,6 +20,7 @@ import (
 
 type Operator struct {
 	namespace      string
+	defaultResync  time.Duration
 	config         *rest.Config
 	clientset      *kubernetes.Clientset
 	resource       schema.GroupVersionResource
@@ -47,6 +48,14 @@ type Option func(op *Operator)
 func WithNamespace(namespace string) Option {
 	return func(op *Operator) {
 		op.namespace = namespace
+	}
+}
+
+// WithDefaultResync configures an operator to resync after timeout is reached.
+// By default or when an a timeout of 0 is set, the operator does not resync.
+func WithDefaultResync(t time.Duration) Option {
+	return func(op *Operator) {
+		op.defaultResync = t
 	}
 }
 
@@ -116,7 +125,7 @@ func New(options ...Option) *Operator {
 
 func (op *Operator) Run() error {
 	if op.informer == nil {
-		informer, err := newK8sInformer(op.config, op.namespace, op.resource, op.resourceType)
+		informer, err := newK8sInformer(op.config, op.namespace, op.defaultResync, op.resource, op.resourceType)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This Pull Request adds the option to set the default resync duration. Without resync you run the risk to lose Kubernetes events with long running operators or if you receive a lot of events at once.